### PR TITLE
Keyring: accessor for backend

### DIFF
--- a/keyring.gemspec
+++ b/keyring.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'mocha'
-  spec.add_dependency 'slop'
+  spec.add_dependency 'slop', "< 4.0"
 
   if RUBY_PLATFORM =~ /linux/
     spec.add_dependency 'gir_ffi-gnome_keyring', '~> 0.0.3'

--- a/lib/keyring.rb
+++ b/lib/keyring.rb
@@ -5,6 +5,8 @@ require "keyring/version"
 
 class Keyring
   require 'keyring/backend'
+
+  attr_reader :backend
   
   # If you want a particular backend then use, for example,
   # Keyring.new(Keyring::Backend::Memory.new)

--- a/test/test_keyring.rb
+++ b/test/test_keyring.rb
@@ -19,6 +19,10 @@ class KeyringTests < Test::Unit::TestCase
     keyring = Keyring.new(backend)
     assert_equal backend, keyring.instance_variable_get(:@backend)
   end
+
+  def test_backend
+    assert_equal @backend, @keyring.backend
+  end
   
   def test_get_password
     @backend.expects(:get_password).with('service', 'username').returns('password')


### PR DESCRIPTION
In order to simply check which backend was chosen, I've added

    attr_reader backend

in the class `Keyring`.

Now you can easily do things like

    @kr = Keyring.new
    unless %w(GnomeKeyring MacosxKeychain).include?(@kr.backend.class.name.split(/::/).last) 
      warn "Your password will not be stored persistently!"
    end

Additionally, I limited the version of  `slop` to be < 4.0 : `slop` has completely refactored the API
as of version 4.0