### PR TITLE
Platform Specific Gem Installation

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,0 +1,1 @@
+task :default

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,23 @@
+# http://en.wikibooks.org/wiki/Ruby_Programming/RubyGems#How_to_install_different_versions_of_gems_depending_on_which_version_of_ruby_the_installee_is_using
+
+require 'rubygems'
+require 'rubygems/command.rb'
+require 'rubygems/dependency_installer.rb' 
+begin
+  Gem::Command.build_args = ARGV
+rescue NoMethodError
+end 
+inst = Gem::DependencyInstaller.new
+begin
+  if RUBY_PLATFORM =~ /linux/
+    warn "*linux: installing gir_ffi-gnome_keyring..."
+    inst.install "gir_ffi-gnome_keyring", '~> 0.0.3'
+  end
+rescue
+  exit(1)
+end 
+
+# create dummy Rakefile to indicate success
+f = File.open(File.join(File.dirname(__FILE__), "Rakefile"), "w")
+f.write("task :default\n")
+f.close

--- a/keyring.gemspec
+++ b/keyring.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha'
   spec.add_dependency 'slop', "< 4.0"
 
-  if RUBY_PLATFORM =~ /linux/
-    spec.add_dependency 'gir_ffi-gnome_keyring', '~> 0.0.3'
-  end
+  spec.extensions = %w[ext/mkrf_conf.rb]
+  # if RUBY_PLATFORM =~ /linux/
+  #   spec.add_dependency 'gir_ffi-gnome_keyring', '~> 0.0.3'
+  # end
 end

--- a/lib/keyring/version.rb
+++ b/lib/keyring/version.rb
@@ -2,5 +2,5 @@
 # License: MIT (http://www.opensource.org/licenses/mit-license.php)
 
 class Keyring
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Hi again!

When I first wanted to use the library (on Ubuntu), I was struggling because the GnomeKeyring backend seemed to be broken. Only after rereading the README and looking at the `keyring.gemspec` I've found out that I had to manually install `gir_ffi-gnome_keyring`.

Based on this guide http://en.wikibooks.org/wiki/Ruby_Programming/RubyGems#How_to_install_different_versions_of_gems_depending_on_which_version_of_ruby_the_installee_is_using
I added a file `ext/mkrf_conf.rb` that installs the `gir_ffi-gnome_keyring` gem automatically, when installed on a linux machine.

I've not really tested it on Mac OS X, but I was able to install it (as part of another, internal gem).

On Ubuntu, it works fine. There's no need to manually install the `gir_ffi-gnome_keyring` gem.

Regards
andi