### PR TITLE
Improve platform matching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in keyring.gemspec
 gemspec
 
-# Duplicated contents of ext/mkrf_conf.rb here - afaict, the
-# spec.extensions stuff in the gemspec file doesn't run on a 
-# bundle install
-
-gem 'ruby-keychain', '~> 0.3.2'
-
 group :test, :development do
   gem 'test-unit'
 end

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,5 +1,6 @@
 # http://en.wikibooks.org/wiki/Ruby_Programming/RubyGems#How_to_install_different_versions_of_gems_depending_on_which_version_of_ruby_the_installee_is_using
 
+
 require 'rubygems'
 require 'rubygems/command.rb'
 require 'rubygems/dependency_installer.rb' 
@@ -10,12 +11,11 @@ end
 inst = Gem::DependencyInstaller.new
 begin
 
-  if RUBY_PLATFORM =~ /linux/
+  case Gem::Platform.local.os
+  when 'linux'
     warn "*linux: installing gir_ffi-gnome_keyring..."
     inst.install "gir_ffi-gnome_keyring", '~> 0.0.3'
-  end
-
-  if RUBY_PLATFORM =~ /darwin10/
+  when 'darwin'
     warn '*osx: installing ruby-keychain'
     inst.install 'ruby-keychain', '~> 0.3.2'
   end

--- a/keyring.gemspec
+++ b/keyring.gemspec
@@ -26,6 +26,16 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha'
   spec.add_dependency 'slop', "< 4.0"
 
+  # Note that when updating these versions you must also make
+  # equivalent changes in ext/mkrf_conf.rb
+
+  case Gem::Platform.local.os
+    when 'linux'
+      spec.add_dependency "gir_ffi-gnome_keyring", '~> 0.0.3'
+    when 'darwin'
+      spec.add_dependency 'ruby-keychain', '~> 0.3.2'
+  end
+
   spec.extensions = %w[ext/mkrf_conf.rb]
 
 end


### PR DESCRIPTION
My previous PR had incorrect code for identifying a platform as Mac OSX.  I've improved the platform matching, and added the conditional dependencies to the gemspec too, as these otherwise don't seem to be picked up when this module is used via bundler in other projects.
